### PR TITLE
Add feature to show people a user follows on github

### DIFF
--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -10,4 +10,10 @@ class UserFacade
       Follower.new(hash)
     end
   end
+
+  def following
+    GithubService.new.get_following.map do |hash|
+      Following.new(hash)
+    end
+  end
 end

--- a/app/facades/user_facade.rb
+++ b/app/facades/user_facade.rb
@@ -1,19 +1,19 @@
 class UserFacade
   def repos
-    GithubService.new.get_repos.map do |hash|
-      Repo.new(hash)
-    end.first(5)
+    service.get_repos.map { |hash| Repo.new(hash) }.first(5)
   end
 
   def followers
-    GithubService.new.get_followers.map do |hash|
-      Follower.new(hash)
-    end
+    service.get_followers.map { |hash| Follower.new(hash) }
   end
 
   def following
-    GithubService.new.get_following.map do |hash|
-      Following.new(hash)
-    end
+    service.get_following.map { |hash| Following.new(hash) }
+  end
+
+  private
+
+  def service
+    @_service ||= GithubService.new
   end
 end

--- a/app/models/following.rb
+++ b/app/models/following.rb
@@ -1,0 +1,8 @@
+class Following
+  attr_reader :user_name, :html_url
+
+  def initialize(hash)
+    @user_name = hash[:login]
+    @html_url = hash[:html_url]
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,26 +1,14 @@
 class GithubService
   def get_repos
-    response = conn.get do |req|
-      req.url 'user/repos'
-      req.params['affiliation'] = 'owner'
-    end
-    JSON.parse(response.body, symbolize_names: true)
+    get_json('user/repos')
   end
 
   def get_followers
-    response = conn.get do |req|
-      req.url 'user/followers'
-      req.params['affiliation'] = 'owner'
-    end
-    JSON.parse(response.body, symbolize_names: true)
+    get_json('user/followers')
   end
 
   def get_following
-    response = conn.get do |req|
-      req.url 'user/following'
-      req.params['affiliation'] = 'owner'
-    end
-    JSON.parse(response.body, symbolize_names: true)
+    get_json('user/following')
   end
 
   private
@@ -28,5 +16,13 @@ class GithubService
   def conn
     Faraday.new('https://api.github.com/',
       headers: {'Authorization' => "bearer #{ENV['GITHUB_API_KEY']}"})
+  end
+
+  def get_json(path)
+    response = conn.get do |req|
+      req.url path
+      req.params['affiliation'] = 'owner'
+    end
+    JSON.parse(response.body, symbolize_names: true)
   end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -15,6 +15,14 @@ class GithubService
     JSON.parse(response.body, symbolize_names: true)
   end
 
+  def get_following
+    response = conn.get do |req|
+      req.url 'user/following'
+      req.params['affiliation'] = 'owner'
+    end
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
   private
 
   def conn

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,15 @@
           <li><%= link_to follower.user_name, follower.html_url, class: 'follower-link' %></li>
         <% end %>
       </ul>
+    </section>
 
+    <section class='github-following'>
+      <h3>Following</h3>
+      <ul>
+        <% @user.following.each do |following| %>
+          <li><%= link_to following.user_name, following.html_url, class: 'following-link' %></li>
+        <% end %>
+      </ul>
     </section>
   </section>
 </section>

--- a/spec/features/user/user_can_see_a_list_of_following_spec.rb
+++ b/spec/features/user/user_can_see_a_list_of_following_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'As a registered user' do
+  it 'can see list of people they follow that are links' do
+    user = create(:user)
+
+    visit login_path
+
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+
+    click_on 'Log In'
+
+    within '.github-info' do
+      expect(page).to have_content('GitHub')
+      within '.github-following' do
+        expect(page).to have_css('.following-link')
+      end
+    end
+  end
+end

--- a/spec/models/following_spec.rb
+++ b/spec/models/following_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe 'Following' do
+  before :each do
+    @following = Following.new({login: 'bobross', html_url: 'example.com'})
+  end
+
+  it 'can initialize with a hash of user_name and url' do
+    expect(@following).to be_an_instance_of(Following)
+  end
+
+  it 'has attributes user_name, url' do
+    expect(@following.user_name).to eq('bobross')
+    expect(@following.html_url).to eq('example.com')
+  end
+end


### PR DESCRIPTION
Adds the following:
- feature test: user can see the people they follow on github as links to that persons gh account
- model test: Following, a person that the user follows
- refactor of user_facade and github_service to reuse creation of service and api calls to various endpoints