### PR TITLE
GitHub oauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'will_paginate'
 gem 'acts-as-taggable-on', '~> 6.0'
 gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census"
 gem 'rubocop', '~> 0.75.0', require: false
+gem 'omniauth-github', '1.1.1'
 
 group :test do
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,9 @@ GEM
     omniauth (1.8.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
+    omniauth-github (1.1.1)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (~> 1.1)
     omniauth-google-oauth2 (0.5.3)
       jwt (>= 1.5)
       omniauth (>= 1.1.1)
@@ -359,6 +362,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.2)
   omniauth-census!
+  omniauth-github (= 1.1.1)
   omniauth-google-oauth2
   pg (>= 0.18, < 2.0)
   pry

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,14 @@ class UsersController < ApplicationController
     end
   end
 
+  def update
+    token = request.env["omniauth.auth"]["credentials"]["token"]
+    user = User.find(current_user.id)
+    user.token = token
+    user.save
+    redirect_to dashboard_path
+  end
+
   private
 
   def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :videos, through: :user_videos
 
   validates :email, uniqueness: true, presence: true
-  validates_presence_of :password
+  validates_presence_of :password_digest
   validates_presence_of :first_name
   enum role: [:default, :admin]
   has_secure_password

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -42,6 +42,6 @@
       </section>
     </section>
   <% else %>
-    <p><%= link_to 'Connect to your GitHub account?', '#' %></p>
+    <p><%= link_to "Connect to Github", "/auth/github" %></p>
   <% end %>
 </section>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,15 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # mock omniauth for GitHub
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+      'provider' => 'github',
+      'uid' => '123545',
+      'credentials' => {
+        'token' => ENV['GITHUB_API_KEY'],
+        'secret' => 'mock_secret'
+      }
+    })
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,4 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+  provider :github, ENV['GITHUB_CLIENT_ID'], ENV['GITHUB_CLIENT_SECRET']
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   get 'tags/:tag', to: 'welcome#index', as: :tag
   get '/register', to: 'users#new'
 
+  get '/auth/github', as: 'github_login'
+  get '/auth/github/callback', to: 'users#update'
+
   namespace :admin do
     get "/dashboard", to: "dashboard#show"
     resources :tutorials, only: [:create, :edit, :update, :destroy, :new] do

--- a/spec/features/user/user_can_link_github_account_spec.rb
+++ b/spec/features/user/user_can_link_github_account_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 describe 'A registered user' do
   it 'can click a link to connect to GitHub and see their repos, followers, and following' do
+    VCR.turn_off!
+    stub_default_github_info
+
     user = create(:user)
 
     visit login_path
@@ -11,12 +14,13 @@ describe 'A registered user' do
 
     click_on 'Log In'
 
+    visit dashboard_path
+
     expect(page).to have_link("Connect to Github")
 
     click_on "Connect to Github"
 
     expect(page).to_not have_link("Connect to Github")
     expect(page).to have_css(".github-info")
-
   end
 end

--- a/spec/features/user/user_can_link_github_account_spec.rb
+++ b/spec/features/user/user_can_link_github_account_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'A registered user' do
+  it 'can click a link to connect to GitHub and see their repos, followers, and following' do
+    user = create(:user)
+
+    visit login_path
+
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: user.password
+
+    click_on 'Log In'
+
+    expect(page).to have_link("Connect to Github")
+
+    click_on "Connect to Github"
+    
+    expect(page).to_not have_link("Connect to Github")
+    expect(page).to have_css(".github-info")
+  end
+end

--- a/spec/features/user/user_can_link_github_account_spec.rb
+++ b/spec/features/user/user_can_link_github_account_spec.rb
@@ -14,8 +14,9 @@ describe 'A registered user' do
     expect(page).to have_link("Connect to Github")
 
     click_on "Connect to Github"
-    
+
     expect(page).to_not have_link("Connect to Github")
     expect(page).to have_css(".github-info")
+
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe User, type: :model do
   describe 'validations' do
     it {should validate_presence_of(:email)}
     it {should validate_presence_of(:first_name)}
-    it {should validate_presence_of(:password)}
+    it {should validate_presence_of(:password_digest)}
   end
 
   describe 'roles' do
@@ -18,7 +18,7 @@ RSpec.describe User, type: :model do
 
     it 'can be created as default user with token' do
       user = User.create(email: 'user@email.com', password: 'password', first_name:'Jim', role: 0, token: 'randomstring')
-      
+
       expect(user).to be_an_instance_of(User)
     end
 


### PR DESCRIPTION
This PR adds the following:
- Add feature test for OAuth account linking and displaying github data on user dashboard
- When a user clicks "Connect to GitHub", it calls API to fetch their github info and stores github access token to user token attribute