### PR TITLE
Users add and remove friends

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,15 @@
 class ApplicationController < ActionController::Base
+  helper_method :app_user?
   helper_method :current_user
   helper_method :find_bookmark
   helper_method :list_tags
   helper_method :tutorial_name
 
   add_flash_types :success
+
+  def app_user?(user)
+    !!Identity.find_by(user_name: user.user_name)
+  end
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,0 +1,5 @@
+class FriendshipsController < ApplicationController
+  def create
+
+  end
+end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -10,4 +10,21 @@ class FriendshipsController < ApplicationController
     end
     redirect_to dashboard_path
   end
+
+  def destroy
+    friendship = Friendship.find_by(friendship_params)
+    user = User.find(params[:friend_id])
+    if friendship.delete
+      flash[:success] = "You removed #{user.first_name} #{user.last_name} from your friends list."
+    else
+      flash[:error] = "Unable to remove friend at this time."
+    end
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def friendship_params
+    params.permit(:friend_id, :user_id)
+  end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,5 +1,13 @@
 class FriendshipsController < ApplicationController
   def create
+    identity = Identity.find_by(user_name: params[:friend_name])
+    friendship = current_user.friendships.build(friend_id: identity.user_id)
 
+    if friendship.save
+      flash[:success] = "You've added #{identity.user_name} to your friends list!"
+    else
+      flash[:error] = "Unable to add friend"
+    end
+    redirect_to dashboard_path
   end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,6 +1,6 @@
 class Friendship < ApplicationRecord
   validates_presence_of :user_id, :friend_id
 
-  belongs_to :user
+  belongs_to :user, class_name: 'User'
   belongs_to :friend, class_name: 'User'
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,6 +1,6 @@
 class Friendship < ApplicationRecord
   validates_presence_of :user_id, :friend_id
 
-  belongs_to :user, class_name: 'User'
+  belongs_to :user
   belongs_to :friend, class_name: 'User'
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -1,0 +1,6 @@
+class Friendship < ApplicationRecord
+  validates_presence_of :user_id, :friend_id
+
+  belongs_to :user
+  belongs_to :friend, class_name: 'User'
+end

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -5,4 +5,9 @@ class GithubUser
     @user_name = hash[:login]
     @html_url = hash[:html_url]
   end
+
+  def is_friend_of?(current_user)
+    friend_id = Identity.find_by(user_name: @user_name).user_id
+    !!Friendship.find_by(user_id: current_user.id, friend_id: friend_id)
+  end
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,0 +1,5 @@
+class Identity < ApplicationRecord
+  validates_presence_of :provider, :uid, :user_id, :username
+
+  belongs_to :user
+end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,5 +1,5 @@
 class Identity < ApplicationRecord
-  validates_presence_of :provider, :uid, :user_id, :username
+  validates_presence_of :provider, :uid, :user_id, :user_name
 
   belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,11 +3,16 @@ class User < ApplicationRecord
   has_many :videos, through: :user_videos
 
   has_many :friendships
-  has_many :friends, class_name: 'User'
+  has_many :friends, class_name: 'User', foreign_key: "id"
+  has_many :identities
 
   validates :email, uniqueness: true, presence: true
   validates_presence_of :password_digest
   validates_presence_of :first_name
   enum role: [:default, :admin]
   has_secure_password
+
+  def gh_user_name
+    identities.where(provider: "github").first.user_name
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ApplicationRecord
   has_many :user_videos
   has_many :videos, through: :user_videos
 
+  has_many :friendships
+  has_many :friends, class_name: 'User'
+
   validates :email, uniqueness: true, presence: true
   validates_presence_of :password_digest
   validates_presence_of :first_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :videos, through: :user_videos
 
   has_many :friendships
-  has_many :friends, class_name: 'User', foreign_key: "id"
+  has_many :friends, through: :friendships
   has_many :identities
 
   validates :email, uniqueness: true, presence: true

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,12 @@
         <h3>Followers</h3>
         <ul>
           <% @user.followers.each do |follower| %>
-            <li><%= link_to follower.user_name, follower.html_url, class: 'follower-link' %></li>
+            <li id='follower-<%= follower.user_name %>'>
+              <%= link_to follower.user_name, follower.html_url, class: 'follower-link' %>
+
+              <%= button_to "Add as Friend", friendships_path %>
+
+            </li>
           <% end %>
         </ul>
       </section>
@@ -36,7 +41,9 @@
         <h3>Following</h3>
         <ul>
           <% @user.following.each do |following| %>
-            <li><%= link_to following.user_name, following.html_url, class: 'following-link' %></li>
+            <li id='following-<%= following.user_name %>'>
+              <%= link_to following.user_name, following.html_url, class: 'following-link' %>
+            </li>
           <% end %>
         </ul>
       </section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,7 +15,10 @@
     <h3>My Friends</h3>
     <% current_user.friends.each do |friend| %>
       <ul>
-        <li id="friend-<%= friend.id %>"> <%= "#{friend.first_name} #{friend.last_name} (#{friend.gh_user_name})" %> </li>
+        <li id="friend-<%= friend.id %>">
+          <%= "#{friend.first_name} #{friend.last_name} (#{friend.gh_user_name})" %>
+          <%= button_to 'Remove Friend', '/friendship', params: {user_id: current_user.id, friend_id: friend.id}, method: :delete %>
+        </li>
       </ul>
     <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -30,7 +30,11 @@
             <li id='follower-<%= follower.user_name %>'>
               <%= link_to follower.user_name, follower.html_url, class: 'follower-link' %>
               <% if app_user?(follower) %>
-                <%= button_to "Add as Friend", friendships_path(friend_name: follower.user_name) %>
+                <% if follower.is_friend_of?(current_user) %>
+                  <%= button_to "Remove Friend", '#', method: :delete  %>
+                <% else %>
+                  <%= button_to "Add as Friend", friendships_path(friend_name: follower.user_name)  %>
+                <% end %>
               <% end %>
             </li>
           <% end %>
@@ -46,9 +50,10 @@
               <% if app_user?(following) %>
                 <% if following.is_friend_of?(current_user) %>
                   <%= button_to "Remove Friend", '#', method: :delete  %>
-                <% end %>
+                <% else %>
                   <%= button_to "Add as Friend", friendships_path(friend_name: following.user_name)  %>
-              <% end %>
+                <% end %>
+              <% end  %>
             </li>
           <% end %>
         </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,6 +10,17 @@
   <section>
     <h3>Bookmarked Segments</h3>
   </section>
+
+  <section class='friends-list'>
+    <h3>My Friends</h3>
+    <% current_user.friends.each do |friend| %>
+      <ul>
+        <li id="friend-<%= friend.id %>"> <%= "#{friend.first_name} #{friend.last_name} (#{friend.gh_user_name})" %> </li>
+      </ul>
+    <% end %>
+
+  </section>
+
   <% if current_user.token %>
     <section class='github-info'>
       <h2>GitHub</h2>
@@ -30,12 +41,10 @@
             <li id='follower-<%= follower.user_name %>'>
               <%= link_to follower.user_name, follower.html_url, class: 'follower-link' %>
               <% if app_user?(follower) %>
-                <% if follower.is_friend_of?(current_user) %>
-                  <%= button_to "Remove Friend", '#', method: :delete  %>
-                <% else %>
+                <% unless follower.is_friend_of?(current_user) %>
                   <%= button_to "Add as Friend", friendships_path(friend_name: follower.user_name)  %>
                 <% end %>
-              <% end %>
+              <% end  %>
             </li>
           <% end %>
         </ul>
@@ -48,9 +57,7 @@
             <li id='following-<%= following.user_name %>'>
               <%= link_to following.user_name, following.html_url, class: 'following-link' %>
               <% if app_user?(following) %>
-                <% if following.is_friend_of?(current_user) %>
-                  <%= button_to "Remove Friend", '#', method: :delete  %>
-                <% else %>
+                <% unless following.is_friend_of?(current_user) %>
                   <%= button_to "Add as Friend", friendships_path(friend_name: following.user_name)  %>
                 <% end %>
               <% end  %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,9 +29,9 @@
           <% @user.followers.each do |follower| %>
             <li id='follower-<%= follower.user_name %>'>
               <%= link_to follower.user_name, follower.html_url, class: 'follower-link' %>
-
-              <%= button_to "Add as Friend", friendships_path %>
-
+              <% if app_user?(follower) %>
+                <%= button_to "Add as Friend", friendships_path(friend_name: follower.user_name) %>
+              <% end %>
             </li>
           <% end %>
         </ul>
@@ -43,6 +43,12 @@
           <% @user.following.each do |following| %>
             <li id='following-<%= following.user_name %>'>
               <%= link_to following.user_name, following.html_url, class: 'following-link' %>
+              <% if app_user?(following) %>
+                <% if following.is_friend_of?(current_user) %>
+                  <%= button_to "Remove Friend", '#', method: :delete  %>
+                <% end %>
+                  <%= button_to "Add as Friend", friendships_path(friend_name: following.user_name)  %>
+              <% end %>
             </li>
           <% end %>
         </ul>

--- a/config/database.yml
+++ b/config/database.yml
@@ -29,9 +29,9 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: brownfield
+  #user_name: brownfield
 
-  # The password associated with the postgres role (username).
+  # The password associated with the postgres role (user_name).
   #password:
 
   # Connect on a TCP socket. Omitted by default since the client uses a

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get '/auth/github/callback', to: 'users#update'
 
   resources :friendships, only: [:create]
+  delete '/friendship', to: 'friendships#destroy'
 
   namespace :admin do
     get "/dashboard", to: "dashboard#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   get '/auth/github', as: :github_auth
   get '/auth/github/callback', to: 'users#update'
 
+  resources :friendships, only: [:create]
+
   namespace :admin do
     get "/dashboard", to: "dashboard#show"
     resources :tutorials, only: [:create, :edit, :update, :destroy, :new] do

--- a/db/migrate/20191012162359_create_identities.rb
+++ b/db/migrate/20191012162359_create_identities.rb
@@ -1,0 +1,13 @@
+class CreateIdentities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :identities do |t|
+      t.string :provider
+      t.integer :uid
+      t.references :user, foreign_key: true
+      t.string :username
+      t.string :image_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20191012162359_create_identities.rb
+++ b/db/migrate/20191012162359_create_identities.rb
@@ -4,7 +4,7 @@ class CreateIdentities < ActiveRecord::Migration[5.2]
       t.string :provider
       t.integer :uid
       t.references :user, foreign_key: true
-      t.string :username
+      t.string :user_name
       t.string :image_url
 
       t.timestamps

--- a/db/migrate/20191012164657_create_friendships.rb
+++ b/db/migrate/20191012164657_create_friendships.rb
@@ -1,0 +1,10 @@
+class CreateFriendships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :friendships do |t|
+      t.integer :user_id
+      t.integer :friend_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_12_162359) do
+ActiveRecord::Schema.define(version: 2019_10_12_164657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "friendships", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "friend_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "identities", force: :cascade do |t|
     t.string "provider"
     t.integer "uid"
     t.bigint "user_id"
-    t.string "username"
+    t.string "user_name"
     t.string "image_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_165043) do
+ActiveRecord::Schema.define(version: 2019_10_12_162359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "identities", force: :cascade do |t|
+    t.string "provider"
+    t.integer "uid"
+    t.bigint "user_id"
+    t.string "username"
+    t.string "image_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_identities_on_user_id"
+  end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
@@ -81,6 +92,7 @@ ActiveRecord::Schema.define(version: 2019_10_10_165043) do
     t.index ["tutorial_id"], name: "index_videos_on_tutorial_id"
   end
 
+  add_foreign_key "identities", "users"
   add_foreign_key "user_videos", "users"
   add_foreign_key "user_videos", "videos"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -115,7 +115,11 @@ m3_tutorial.videos.create!({
   "position"=>6
 })
 
-User.create!(email: 'admin@example.com', first_name: 'Bossy', last_name: 'McBosserton', password:  "password", role: :admin)
-User.create!(email: 'fenton@example.com', first_name: 'Fenton', last_name: 'Taylor', password:  "password", role: :default, token: ENV['GITHUB_API_KEY_FT'])
-User.create!(email: 'nancy@example.com', first_name: 'Nancy', last_name: 'Lee', password:  "password", role: :default, token: ENV['GITHUB_API_KEY_NL'])
-User.create!(email: 'nathan@example.com', first_name: 'Nathan', last_name: 'Thomas', password:  "password", role: :default, token: ENV['GITHUB_API_KEY_NT'])
+
+User.create(email: 'admin@example.com', first_name: 'Bossy', last_name: 'McBosserton', password:  "password", role: :admin)
+ft = User.create(email: 'fenton@example.com', first_name: 'Fenton', last_name: 'Taylor', password:  "password", role: :default, token: ENV['GITHUB_API_KEY_FT'])
+Identity.create(provider: 'github', uid: 1234, user_name: 'fentontaylor', user: ft)
+nl = User.create(email: 'nancy@example.com', first_name: 'Nancy', last_name: 'Lee', password:  "password", role: :default, token: ENV['GITHUB_API_KEY_NL'])
+Identity.create(provider: 'github', uid: 2345, user_name: 'nancylee713', user: nl)
+nt = User.create(email: 'nathan@example.com', first_name: 'Nathan', last_name: 'Thomas', password:  "password", role: :default, token: ENV['GITHUB_API_KEY_NT'])
+Identity.create(provider: 'github', uid: 3456, user_name: 'nathangthomas', user: nt)

--- a/spec/factories/friendships.rb
+++ b/spec/factories/friendships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :friendship do
+    user_id 1
+    friend_id 1
+  end
+end

--- a/spec/factories/identities.rb
+++ b/spec/factories/identities.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     provider "MyString"
     uid 1
     user nil
-    username "MyString"
+    user_name "MyString"
     image_url "MyString"
   end
 end

--- a/spec/factories/identities.rb
+++ b/spec/factories/identities.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :identity do
+    provider "MyString"
+    uid 1
+    user nil
+    username "MyString"
+    image_url "MyString"
+  end
+end

--- a/spec/features/user/user_can_add_and_remove_friends_spec.rb
+++ b/spec/features/user/user_can_add_and_remove_friends_spec.rb
@@ -14,11 +14,10 @@ describe 'A registered user' do
       uid: '123456',
       user_name: 'nancylee713',
       provider: 'github',
-      user_id: @github_follower_user.id
+      user: @github_follower_user
     }
 
     @github_follower_user_identity = Identity.create!(info)
-
     stub_default_github_info
 
     visit login_path
@@ -62,11 +61,28 @@ describe 'A registered user' do
 
     expect(page).to have_content("You've added #{@github_follower_user_identity.user_name} to your friends list!")
 
-    within '.github-followers' do
-      within "#follower-#{@github_follower_user_identity.user_name}" do
-        expect(page).to_not have_button("Add as Friend")
+    within '.friends-list' do
+      user = @github_follower_user
+      github_user_name = @github_follower_user_identity.user_name
+      within "#friend-#{user.id}" do
+        expect(page).to have_content("#{user.first_name} #{user.last_name} (#{github_user_name})")
         expect(page).to have_button("Remove Friend")
       end
     end
+
+    within '.github-followers' do
+      within "#follower-#{@github_follower_user_identity.user_name}" do
+        expect(page).to_not have_button("Add as Friend")
+      end
+    end
   end
+
+  it "can click a link to delete friend" do
+    within '.github-followers' do
+      within "#follower-#{@github_follower_user_identity.user_name}" do
+        expect(page).to_not have_button("Add as Friend")
+      end
+    end
+  end
+
 end

--- a/spec/features/user/user_can_add_and_remove_friends_spec.rb
+++ b/spec/features/user/user_can_add_and_remove_friends_spec.rb
@@ -77,12 +77,33 @@ describe 'A registered user' do
     end
   end
 
-  it "can click a link to delete friend" do
+  it "can click a link to remove a friend" do
+    user = @github_follower_user
+    github_user_name = @github_follower_user_identity.user_name
+
     within '.github-followers' do
-      within "#follower-#{@github_follower_user_identity.user_name}" do
-        expect(page).to_not have_button("Add as Friend")
+      within "#follower-#{github_user_name}" do
+        click_button("Add as Friend")
+      end
+    end
+
+    within '.friends-list' do
+      within "#friend-#{user.id}" do
+        expect(page).to have_button('Remove Friend')
+        click_button('Remove Friend')
+      end
+    end
+
+    within '.friends-list' do
+      expect(page).to_not have_css("#friend-#{user.id}")
+    end
+    
+    expect(page).to have_content("You removed #{user.first_name} #{user.last_name} from your friends list.")
+
+    within '.github-followers' do
+      within "#follower-#{github_user_name}" do
+        expect(page).to have_button('Add as Friend')
       end
     end
   end
-
 end

--- a/spec/features/user/user_can_add_friends_spec.rb
+++ b/spec/features/user/user_can_add_friends_spec.rb
@@ -12,7 +12,7 @@ describe 'A registered user' do
 
     info = {
       uid: '123456',
-      username: 'nancylee713',
+      user_name: 'nancylee713',
       provider: 'github',
       user_id: @github_follower_user.id
     }
@@ -30,49 +30,43 @@ describe 'A registered user' do
   it "can see a link to add friend if their followers or followings are also users of the app" do
     within '.github-info' do
       within '.github-followers' do
-        within "li#follower-#{@github_follower_user_identity.username}" do
+        within "#follower-#{@github_follower_user_identity.user_name}" do
           expect(page).to have_button("Add as Friend")
         end
 
-        within "li#follower-#{@github_follower.username}" do
+        within "#follower-#{@github_follower.user_name}" do
           expect(page).to_not have_button("Add as Friend")
         end
       end
 
       within '.github-following' do
-        within "li#following-#{@github_follower_user_identity.username}" do
+        within "#following-#{@github_follower_user_identity.user_name}" do
           expect(page).to have_button("Add as Friend")
         end
 
-        within "li#following-#{@github_following.username}" do
+        within "#following-#{@github_following.user_name}" do
           expect(page).to_not have_button("Add as Friend")
         end
       end
     end
   end
 
-  it "can click a link to add friend and see its name on dashboard" do
+  it "can click a link to add friend and see friend status next to its name" do
     within '.github-info' do
       within '.github-followers' do
-        within "li#follower-#{@github_follower_user_identity.username}" do
+        within "#follower-#{@github_follower_user_identity.user_name}" do
           click_on "Add as Friend"
         end
       end
     end
 
-    expect(page).to have_content("You've added #{@github_follower_user.first_name} to your friends list!")
+    expect(page).to have_content("You've added #{@github_follower_user_identity.user_name} to your friends list!")
 
     within '.github-followers' do
-      within "li##{@github_follower_user_identity.username}" do
+      within "#follower-#{@github_follower_user_identity.user_name}" do
         expect(page).to_not have_button("Add as Friend")
+        expect(page).to have_button("Remove Friend")
       end
-    end
-
-    within '.friends-list' do
-      expect(page).to have_content('My Friends')
-      expect(page).to have_content(@github_follower_user.first_name)
-      expect(page).to_not have_content(@github_following.username)
-      expect(page).to_not have_content(@github_follower.username)
     end
   end
 end

--- a/spec/features/user/user_can_add_friends_spec.rb
+++ b/spec/features/user/user_can_add_friends_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe 'A registered user' do
+  before :each do
+    @user = create(:user, token: ENV['GITHUB_API_KEY'])
+
+    @github_following = GithubUser.new({login: 'hadley', html_url: 'example.com'})
+
+    @github_follower = GithubUser.new({login: 'vermaph', html_url: 'example.com'})
+
+    @github_follower_user = create(:user, first_name: "Nancy", token: ENV['GITHUB_API_KEY_NL'])
+
+    info = {
+      uid: '123456',
+      username: 'nancylee713',
+      provider: 'github',
+      user_id: @github_follower_user.id
+    }
+
+    @github_follower_user_identity = Identity.create!(info)
+
+    stub_default_github_info
+
+    visit login_path
+    fill_in 'Email', with: @user.email
+    fill_in 'Password', with: @user.password
+    click_on 'Log In'
+  end
+
+  it "can see a link to add friend if their followers or followings are also users of the app" do
+    within '.github-info' do
+      within '.github-followers' do
+        within "li#follower-#{@github_follower_user_identity.username}" do
+          expect(page).to have_button("Add as Friend")
+        end
+
+        within "li#follower-#{@github_follower.username}" do
+          expect(page).to_not have_button("Add as Friend")
+        end
+      end
+
+      within '.github-following' do
+        within "li#following-#{@github_follower_user_identity.username}" do
+          expect(page).to have_button("Add as Friend")
+        end
+
+        within "li#following-#{@github_following.username}" do
+          expect(page).to_not have_button("Add as Friend")
+        end
+      end
+    end
+  end
+
+  it "can click a link to add friend and see its name on dashboard" do
+    within '.github-info' do
+      within '.github-followers' do
+        within "li#follower-#{@github_follower_user_identity.username}" do
+          click_on "Add as Friend"
+        end
+      end
+    end
+
+    expect(page).to have_content("You've added #{@github_follower_user.first_name} to your friends list!")
+
+    within '.github-followers' do
+      within "li##{@github_follower_user_identity.username}" do
+        expect(page).to_not have_button("Add as Friend")
+      end
+    end
+
+    within '.friends-list' do
+      expect(page).to have_content('My Friends')
+      expect(page).to have_content(@github_follower_user.first_name)
+      expect(page).to_not have_content(@github_following.username)
+      expect(page).to_not have_content(@github_follower.username)
+    end
+  end
+end

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Friendship, type: :model do
+  describe 'validations' do
+    it {should validate_presence_of(:user_id)}
+    it {should validate_presence_of(:friend_id)}
+  end
+
+  describe 'relationships' do
+    it {should belong_to :user }
+    it {should belong_to(:friend).class_name("User") }
+  end
+end

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -30,7 +30,6 @@ describe 'GithubUser' do
 
       expect(ghuser_1.is_friend_of?(current_user)).to be true
       expect(ghuser_2.is_friend_of?(current_user)).to be false
-
     end
   end
 end

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -13,4 +13,24 @@ describe 'GithubUser' do
     expect(@user.user_name).to eq('bobross')
     expect(@user.html_url).to eq('example.com')
   end
+
+  describe 'instance methods' do
+    it "#is_friend_of?" do
+      # create 3 users
+      current_user = create(:user, id: 1)
+      user_1 = create(:user, id: 2)
+      user_2 = create(:user, id: 3)
+      ghuser_1 = GithubUser.new(login: 'ghuser-1', html_url: '123@github.com')
+      ghuser_2 = GithubUser.new(login: 'ghuser-2', html_url: '123@github.com')
+      identity_1 = Identity.create(provider: 'github', uid: '1234', user: user_1, user_name: 'ghuser-1')
+      identity_2 = Identity.create(provider: 'github', uid: '1234', user: user_2, user_name: 'ghuser-2')
+
+      # create friendship
+      friendship = Friendship.create(user_id: current_user.id, friend_id: user_1.id)
+
+      expect(ghuser_1.is_friend_of?(current_user)).to be true
+      expect(ghuser_2.is_friend_of?(current_user)).to be false
+
+    end
+  end
 end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe Identity, type: :model do
     it {should validate_presence_of(:provider)}
     it {should validate_presence_of(:uid)}
     it {should validate_presence_of(:user_id)}
-    it {should validate_presence_of(:username)}
+    it {should validate_presence_of(:user_name)}
   end
 end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Identity, type: :model do
+  describe 'validations' do
+    it {should validate_presence_of(:provider)}
+    it {should validate_presence_of(:uid)}
+    it {should validate_presence_of(:user_id)}
+    it {should validate_presence_of(:username)}
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,14 @@ RSpec.describe User, type: :model do
     it {should validate_presence_of(:password_digest)}
   end
 
+  describe 'relationships' do
+    it {should have_many :user_videos }
+    it {should have_many(:videos).through(:user_videos) }
+    it {should have_many :friendships }
+    it {should have_many :friends }
+    it {should have_many :identities }
+
+  end
   describe 'roles' do
     it 'can be created as default user without token' do
       user = User.create(email: 'user@email.com', password: 'password', first_name:'Jim', role: 0)
@@ -27,6 +35,15 @@ RSpec.describe User, type: :model do
 
       expect(admin.role).to eq('admin')
       expect(admin.admin?).to be_truthy
+    end
+  end
+
+  describe 'instance methods' do
+    it "#gh_user_name" do
+      current_user = create(:user, id: 1)
+      identity_1 = Identity.create(provider: 'github', uid: '1234', user: current_user, user_name: 'ghuser-1')
+
+      expect(current_user.gh_user_name).to eq('ghuser-1')
     end
   end
 end


### PR DESCRIPTION
Adds the following:
- Update user dashboard to allow them to add users as friends if they have a are follower or following that user on GitHub and are users of our app.
- Identity model: created when user authenticates with OmniAuth
- Friendship model: created when user clicks button to 'Add as Friend'
- Feature test for adding and removing friends. Model tests for Identity and Friendship. 
