### PR TITLE
[Merge, pending review] Tutorial restriction

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   helper_method :find_bookmark
   helper_method :list_tags
   helper_method :tutorial_name
+  helper_method :restricted_tutorial?
 
   add_flash_types :success
 
@@ -21,6 +22,10 @@ class ApplicationController < ActionController::Base
 
   def tutorial_name(id)
     Tutorial.find(id).title
+  end
+
+  def restricted_tutorial?(tutorial)
+    !tutorial.classroom || current_user
   end
 
   def four_oh_four

--- a/app/facades/tutorial_facade.rb
+++ b/app/facades/tutorial_facade.rb
@@ -1,6 +1,6 @@
 class TutorialFacade < SimpleDelegator
   def initialize(tutorial, video_id = nil)
-    super(tutorial)
+    @tutorial = super(tutorial)
     @video_id = video_id
   end
 
@@ -18,6 +18,10 @@ class TutorialFacade < SimpleDelegator
 
   def play_next_video?
     !(current_video.position >= maximum_video_position)
+  end
+
+  def restricted?
+    @tutorial.classroom
   end
 
   private

--- a/app/facades/tutorial_facade.rb
+++ b/app/facades/tutorial_facade.rb
@@ -1,4 +1,6 @@
 class TutorialFacade < SimpleDelegator
+  attr_reader :tutorial
+
   def initialize(tutorial, video_id = nil)
     @tutorial = super(tutorial)
     @video_id = video_id
@@ -18,10 +20,6 @@ class TutorialFacade < SimpleDelegator
 
   def play_next_video?
     !(current_video.position >= maximum_video_position)
-  end
-
-  def restricted?
-    @tutorial.classroom
   end
 
   private

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -1,69 +1,76 @@
-<main class="tutorials">
-<h2><%= @facade.title %></h2>
-<h1 id="message"></h1>
-<div class="col col-4">
-  <h4>Videos</h4>
-  <ul>
-    <% @facade.videos.each do |video| %>
-      <li>
-        <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
-      </li>
-    <% end %>
-  </ul>
-</div>
-
-<div class="col col-8">
-  <div class="title-bookmark">
-    <h3><%= @facade.current_video.title %></h3>
-    <div class="bookmarks-btn">
-      <% if current_user %>
-      <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
-      <% else %>
-      <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+<% if restricted_tutorial?(@facade.tutorial) %>
+  <main class="tutorials">
+  <h2><%= @facade.title %></h2>
+  <h1 id="message"></h1>
+  <div class="col col-4">
+    <h4>Videos</h4>
+    <ul>
+      <% @facade.videos.each do |video| %>
+        <li>
+          <h3><%= link_to video.title, tutorial_path(video_id: video.id), class: "show-link", id: video.position %></h3>
+        </li>
       <% end %>
-    </div>
+    </ul>
   </div>
 
-  <div id="player">
-    <script src="https://www.youtube.com/player_api"></script>
-    <script>
-    // create youtube player
-    var player;
-    var position;
-    function onYouTubePlayerAPIReady() {
-      player = new YT.Player('player', {
-        width: '640',
-        height: '390',
-        videoId: '<%= @facade.current_video.video_id %>',
-        events: {
-          onReady: onPlayerReady,
-          onStateChange: onPlayerStateChange
-        }
-      });
-    }
+  <div class="col col-8">
+    <div class="title-bookmark">
+      <h3><%= @facade.current_video.title %></h3>
+      <div class="bookmarks-btn">
+        <% if current_user %>
+        <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
+        <% else %>
+        <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+        <% end %>
+      </div>
+    </div>
 
-    // autoplay video
-    function onPlayerReady(event) {
-      event.target.playVideo();
-    }
-
-    // when video ends
-    function onPlayerStateChange(event) {
-      if(event.data === 0 && <%= @facade.play_next_video? %>) {
-        window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
-      } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
-        const message = document.querySelector(`#message`);
-        message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+    <div id="player">
+      <script src="https://www.youtube.com/player_api"></script>
+      <script>
+      // create youtube player
+      var player;
+      var position;
+      function onYouTubePlayerAPIReady() {
+        player = new YT.Player('player', {
+          width: '640',
+          height: '390',
+          videoId: '<%= @facade.current_video.video_id %>',
+          events: {
+            onReady: onPlayerReady,
+            onStateChange: onPlayerStateChange
+          }
+        });
       }
-    }
-  </script>
-</div>
 
-  <h4>Description</h4>
-  <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
-    <%= @facade.current_video.description.truncate(50) %>...
-    <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
-  </p>
-</div>
+      // autoplay video
+      function onPlayerReady(event) {
+        event.target.playVideo();
+      }
 
-</main>
+      // when video ends
+      function onPlayerStateChange(event) {
+        if(event.data === 0 && <%= @facade.play_next_video? %>) {
+          window.location = "/tutorials/<%=@facade.id%>?video_id=<%=@facade.next_video.id %>";
+        } else if(event.data === 0 && <%= @facade.play_next_video? == false %>) {
+          const message = document.querySelector(`#message`);
+          message.innerHTML = "You watched them all. Bask in the glory of your new skills."
+        }
+      }
+    </script>
+  </div>
+
+    <h4>Description</h4>
+    <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
+      <%= @facade.current_video.description.truncate(50) %>...
+      <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
+    </p>
+  </div>
+
+  </main>
+<% else %>
+  <div class="login-warning">
+    <h3>You must be logged in to view this content.</h3>
+    <h4>Please sign in or create a free account.</h4>
+  </div>
+<% end %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,7 +4,7 @@
 </div>
 <section class="tutorials col md-col-8">
   <% @tutorials.each do |tutorial| %>
-    <% if !tutorial.classroom || current_user %>
+    <% if restricted_tutorial?(tutorial) %>
       <div class="tutorial">
         <img class="thumbnail col md-col-3" src= <%="#{tutorial.thumbnail}" %> >
         <div class="tutorial-description col md-col-9">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -4,13 +4,15 @@
 </div>
 <section class="tutorials col md-col-8">
   <% @tutorials.each do |tutorial| %>
-    <div class="tutorial">
-      <img class="thumbnail col md-col-3" src= <%="#{tutorial.thumbnail}" %> >
-      <div class="tutorial-description col md-col-9">
-        <h4 class="tutorial-title-home"><%= link_to tutorial.title, tutorial_path(tutorial), class: "title-link" %> </h4>
-        <p class="description"><%= tutorial.description %></p> <br>
-      </div>
-    </div> <br>
+    <% if !tutorial.classroom || current_user %>
+      <div class="tutorial">
+        <img class="thumbnail col md-col-3" src= <%="#{tutorial.thumbnail}" %> >
+        <div class="tutorial-description col md-col-9">
+          <h4 class="tutorial-title-home"><%= link_to tutorial.title, tutorial_path(tutorial), class: "title-link" %> </h4>
+          <p class="description"><%= tutorial.description %></p> <br>
+        </div>
+      </div> <br>
+    <% end %>
   <% end %>
   <hr>
   <br>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,7 +42,7 @@ mod_1_tutorial_data = {
   "description"=>"Videos related to Mod 1.",
   "thumbnail"=>"https://i.ytimg.com/vi/tZDBWXZzLPk/hqdefault.jpg",
   "playlist_id"=>"PL1Y67f0xPzdNsXqiJs1s4NlpI6ZMNdMsb",
-  "classroom"=>false,
+  "classroom"=>true,
 }
 
 m1_tutorial = Tutorial.create! mod_1_tutorial_data
@@ -67,7 +67,7 @@ mod_3_tutorial_data = {
   "description"=>"Video content for Mod 3.",
   "thumbnail"=>"https://i.ytimg.com/vi/R5FPYQgB6Zc/hqdefault.jpg",
   "playlist_id"=>"PL1Y67f0xPzdOq2FcpWnawJeyJ3ELUdBkJ",
-  "classroom"=>false,
+  "classroom"=>true,
   "tag_list"=>["Internet", "BDD", "Ruby"],
 }
 m3_tutorial = Tutorial.create! mod_3_tutorial_data

--- a/spec/features/tutorials/only_logged_in_users_see_classroom_content_spec.rb
+++ b/spec/features/tutorials/only_logged_in_users_see_classroom_content_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe "'Classroom' tutorials are restricted" do
+  before :each do
+    @non_classroom = create(:tutorial, classroom: false)
+    @vid_1 = create(:video, tutorial: @non_classroom)
+
+    @classroom = create(:tutorial, classroom: true)
+    @vid_2 = create(:video, tutorial: @non_classroom)
+  end
+
+  context 'As a non-logged-in visitor' do
+    it 'I CANNOT see videos marked as "classroom"' do
+      visit '/'
+
+      expect(page).to have_css('.tutorial', count: 1)
+      expect(page).to have_content(@non_classroom.title)
+    end
+  end
+
+  context 'As a logged-in user' do
+    it 'I CAN see videos marked as "classroom"' do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit '/'
+
+      expect(page).to have_css('.tutorial', count: 2)
+      expect(page).to have_content(@non_classroom.title)
+      expect(page).to have_content(@classroom.title)
+    end
+  end
+end

--- a/spec/features/tutorials/only_logged_in_users_see_classroom_content_spec.rb
+++ b/spec/features/tutorials/only_logged_in_users_see_classroom_content_spec.rb
@@ -25,21 +25,35 @@ describe "'Classroom' tutorials are restricted" do
 
       visit "/tutorials/#{@classroom.id}"
       expect(page).to have_content("You must be logged in to view this content.")
-      expect(page).to have_content("Please log in or create a free account.")
+      expect(page).to have_content("Please sign in or create a free account.")
       expect(page).to_not have_css('#player')
     end
   end
 
   context 'As a logged-in user' do
-    it 'I CAN see videos marked as "classroom"' do
+    before :each do
       user = create(:user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    end
 
+    it 'I CAN see videos marked as "classroom"' do
       visit '/'
 
       expect(page).to have_css('.tutorial', count: 2)
       expect(page).to have_content(@non_classroom.title)
       expect(page).to have_content(@classroom.title)
+    end
+
+    it 'I CAN manually visit a restricted tutorial' do
+      visit "/tutorials/#{@non_classroom.id}"
+
+      expect(page).to have_content(@non_classroom.title)
+      expect(page).to have_css('#player')
+
+      visit "/tutorials/#{@classroom.id}"
+
+      expect(page).to have_content(@classroom.title)
+      expect(page).to have_css('#player')
     end
   end
 end

--- a/spec/features/tutorials/only_logged_in_users_see_classroom_content_spec.rb
+++ b/spec/features/tutorials/only_logged_in_users_see_classroom_content_spec.rb
@@ -6,7 +6,7 @@ describe "'Classroom' tutorials are restricted" do
     @vid_1 = create(:video, tutorial: @non_classroom)
 
     @classroom = create(:tutorial, classroom: true)
-    @vid_2 = create(:video, tutorial: @non_classroom)
+    @vid_2 = create(:video, tutorial: @classroom)
   end
 
   context 'As a non-logged-in visitor' do
@@ -15,6 +15,18 @@ describe "'Classroom' tutorials are restricted" do
 
       expect(page).to have_css('.tutorial', count: 1)
       expect(page).to have_content(@non_classroom.title)
+    end
+
+    it 'I CANNOT manually visit a restricted tutorial' do
+      visit "/tutorials/#{@non_classroom.id}"
+
+      expect(page).to have_content(@non_classroom.title)
+      expect(page).to have_css('#player')
+
+      visit "/tutorials/#{@classroom.id}"
+      expect(page).to have_content("You must be logged in to view this content.")
+      expect(page).to have_content("Please log in or create a free account.")
+      expect(page).to_not have_css('#player')
     end
   end
 

--- a/spec/features/tutorials/only_logged_in_users_see_classroom_content_spec.rb
+++ b/spec/features/tutorials/only_logged_in_users_see_classroom_content_spec.rb
@@ -15,6 +15,7 @@ describe "'Classroom' tutorials are restricted" do
 
       expect(page).to have_css('.tutorial', count: 1)
       expect(page).to have_content(@non_classroom.title)
+      expect(page).to_not have_content(@classroom.title)
     end
 
     it 'I CANNOT manually visit a restricted tutorial' do


### PR DESCRIPTION
Users who are not logged in should not be able to view tutorials marked as classroom content, i.e. have the attribute `classroom = true`.

*Adds the following:*
- Tests for
    - Viewing tutorials on homepage as visitor and logged-in user
    - Manually visiting tutorial show pages as visitor and logged-in user
- Conditional rendering in homepage  and tutorial show page, handled by the ApplicationController method `restricted_tutorial?` which takes one argument: a tutorial object.

*This feature is fully tested in the test and development environment and is ready to merge*