### PR TITLE
Bookmark display message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'acts-as-taggable-on', '~> 6.0'
 gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census"
 gem 'rubocop', '~> 0.75.0', require: false
 gem 'omniauth-github', '1.1.1'
+gem 'sprockets-rails'
+gem 'bootstrap'
+gem 'jquery-rails'
 
 group :test do
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    autoprefixer-rails (9.6.5)
+      execjs
     awesome_print (1.8.0)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -69,6 +71,10 @@ GEM
     bindex (0.5.0)
     bootsnap (1.3.1)
       msgpack (~> 1.0)
+    bootstrap (4.3.1)
+      autoprefixer-rails (>= 9.1.0)
+      popper_js (>= 1.14.3, < 2)
+      sassc-rails (>= 2.0.0)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.6.0)
@@ -148,6 +154,10 @@ GEM
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     jquery (0.0.1)
+    jquery-rails (4.3.5)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.1.0)
     jsonapi-renderer (0.2.0)
     jwt (1.5.6)
@@ -215,6 +225,7 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.0.0)
+    popper_js (1.14.5)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -296,6 +307,14 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
@@ -381,6 +400,7 @@ DEPENDENCIES
   awesome_print
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
+  bootstrap
   byebug
   capybara
   coffee-rails (~> 4.2)
@@ -393,6 +413,7 @@ DEPENDENCIES
   google-api-client
   jbuilder (~> 2.5)
   jquery
+  jquery-rails
   launchy
   listen (>= 3.0.5, < 3.2)
   mailcatcher
@@ -409,6 +430,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers
   simplecov
+  sprockets-rails
   tzinfo-data
   vcr
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,7 @@
 //= require rails-ujs
 //= require activestorage
 //= require_tree .
+
+//= require jquery3
+//= require popper
+//= require bootstrap

--- a/app/assets/javascripts/tutorial.js
+++ b/app/assets/javascripts/tutorial.js
@@ -26,3 +26,6 @@ function onPlayerStateChange(event) {
     message.innerHTML = "You watched them all. Bask in the glory of your new skills."
   }
 }
+
+$(document).ready(function() {
+  $('.has-tooltip').tool

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -20,7 +20,11 @@
             <% if current_user %>
               <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
             <% else %>
-              <%= link_to "Bookmark", login_path, class: "btn btn-outline mb1 teal" %>
+            <div class="bookmark">
+              <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-html="true" data-placement="top" title="You must be a registered user to bookmark this tutorial.">
+                <%= link_to "Bookmark", "#", class: "btn btn-outline mb1 teal" %>
+              </button>
+            </div>
             <% end %>
           </div>
       </div>

--- a/spec/features/user/must_be_logged_in_to_bookmark_spec.rb
+++ b/spec/features/user/must_be_logged_in_to_bookmark_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe 'As an unregistered user' do
+  before :each do
+    @tutorial_1 = create(:tutorial)
+    create(:video, tutorial: @tutorial_1)
+
+  end
+
+  it 'when I try to bookmark a video I see a notice informing me that I must be signed in to bookmark.' do
+    visit tutorial_path(@tutorial_1)
+    click_button('Bookmark')
+
+    expect(current_path).to eq(tutorial_path(@tutorial_1))
+  end
+
+  it 'as a registered user I am able to bookmark a video' do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit tutorial_path(@tutorial_1)
+    click_button('Bookmark')
+
+    expect(page).to have_content("Bookmark added to your dashboard!")
+  end
+end


### PR DESCRIPTION
This PR does the following: 
-Adds gems and other necessary dependencies to enable tooltips 
-Tests for the proper routing of bookmark button (Button is disabled for unregistered users. They see a tooltip prompting them to log in to bookmark the tutorial. Registered users are able to bookmark and are rerouted to the tutorial show page.) 

** I ran into some difficulty testing for the tooltip.  Do either of you know how to do this? 

I am afraid I have spent more time than I should have researching and trying different things. Due to time constraints testing for the tooltip may be worth moving on from until all other functionality is complete. 
