### PR TITLE
Email invite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development, :test do
   gem 'vcr'
   gem 'selenium-webdriver'
   gem 'webdrivers'
-  gem 'mailcatcher'
+  # gem 'mailcatcher'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,14 +100,12 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    daemons (1.3.1)
     database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
     diff-lcs (1.3)
     docile (1.3.1)
     erubi (1.7.1)
-    eventmachine (1.2.7)
     execjs (2.7.0)
     factory_bot (4.11.0)
       activesupport (>= 3.0.0)
@@ -141,9 +139,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
-    haml (5.1.2)
-      temple (>= 0.8.0)
-      tilt
     hashdiff (0.3.7)
     hashie (3.5.7)
     httpclient (2.8.3)
@@ -172,16 +167,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
-    mailcatcher (0.2.4)
-      eventmachine
-      haml
-      i18n
-      json
-      mail
-      sinatra
-      skinny (>= 0.1.2)
-      sqlite3-ruby
-      thin
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     memoist (0.16.0)
@@ -197,7 +182,6 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mustermann (1.0.3)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
@@ -232,8 +216,6 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.5)
-    rack-protection (2.0.7)
-      rack
     rack-proxy (0.6.4)
       rack
     rack-test (1.1.0)
@@ -330,14 +312,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (2.0.7)
-      mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.7)
-      tilt (~> 2.0)
-    skinny (0.2.2)
-      eventmachine (~> 1.0)
-      thin
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -349,14 +323,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
-    sqlite3-ruby (1.3.3)
-      sqlite3 (>= 1.3.3)
-    temple (0.8.2)
-    thin (1.7.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -416,7 +382,6 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (>= 3.0.5, < 3.2)
-  mailcatcher
   omniauth-census!
   omniauth-github (= 1.1.1)
   omniauth-google-oauth2

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -3,19 +3,14 @@ class InviteController < ApplicationController
   end
 
   def create
-    handle = params["GitHub Handle"]
-    service = GithubService.new(current_user)
-    data = service.get_email(handle)
-    email = data[:email]
-    real_name = data[:name]
+    facade = InviteFacade.new(params["GitHub Handle"], current_user)
 
-    if data[:message] == 'Not Found'
-      flash[:error] = "Sorry, #{handle} is not a valid GitHub handle."
-    elsif email.nil?
-      flash[:error] = "Sorry, #{handle} does not have a public email."
+    if facade.message == 'Not Found'
+      flash[:error] = "Sorry, #{facade.handle} is not a valid GitHub handle."
+    elsif facade.email.nil?
+      flash[:error] = "Sorry, #{facade.handle} does not have a public email."
     else
-      inviter = current_user.first_name + ' ' + current_user.last_name
-      InvitationMailer.invite(real_name, email, inviter).deliver_now
+      facade.send_invite
       flash[:success] = "Successfully sent invite!"
     end
 

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -1,0 +1,22 @@
+class InviteController < ApplicationController
+  def new
+  end
+
+  def create
+    handle = params["GitHub Handle"]
+    service = GithubService.new(current_user)
+    data = service.get_email(handle)
+    email = data[:email]
+
+    if data[:message] == 'Not Found'
+      flash[:error] = "Sorry, #{handle} is not a valid GitHub handle."
+    elsif email.nil?
+      flash[:error] = "Sorry, #{handle} does not have a public email."
+    else
+      flash[:success] = "Successfully sent invite!"
+    end
+    
+    redirect_to dashboard_path
+  end
+
+end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -7,16 +7,18 @@ class InviteController < ApplicationController
     service = GithubService.new(current_user)
     data = service.get_email(handle)
     email = data[:email]
+    real_name = data[:name]
 
     if data[:message] == 'Not Found'
       flash[:error] = "Sorry, #{handle} is not a valid GitHub handle."
     elsif email.nil?
       flash[:error] = "Sorry, #{handle} does not have a public email."
     else
+      inviter = current_user.first_name + ' ' + current_user.last_name
+      InvitationMailer.invite(real_name, email, inviter).deliver_now
       flash[:success] = "Successfully sent invite!"
     end
-    
+
     redirect_to dashboard_path
   end
-
 end

--- a/app/facades/invite_facade.rb
+++ b/app/facades/invite_facade.rb
@@ -1,0 +1,38 @@
+class InviteFacade
+  attr_reader :handle
+
+  def initialize(handle, user)
+    @handle = handle
+    @user = user
+  end
+
+  def send_invite
+    InvitationMailer.invite(real_name, email, inviter).deliver_now
+  end
+
+  def inviter
+    @user.first_name + ' ' + @user.last_name
+  end
+
+  def message
+    data[:message]
+  end
+
+  def real_name
+    data[:name]
+  end
+
+  def email
+    data[:email]
+  end
+
+  private
+
+  def data
+    @data ||= service.get_email(@handle)
+  end
+
+  def service
+    @service ||= GithubService.new(@user)
+  end
+end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,7 @@
+class InvitationMailer < ApplicationMailer
+  def invite(real_name, email, inviter)
+    @real_name = real_name
+    @inviter = inviter
+    mail(to: email, subject: 'Invitation to Turing Tutorials!')
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -3,6 +3,10 @@ class GithubService
     @user = user
   end
 
+  def get_email(handle)
+    get_json("users/#{handle}")
+  end
+
   def get_repos
     get_json('user/repos')
   end
@@ -18,8 +22,9 @@ class GithubService
   private
 
   def conn
+    token = @user.token? ? @user.token : ENV['GITHUB_API_KEY']
     Faraday.new('https://api.github.com/',
-      headers: {'Authorization' => "bearer #{@user.token}"})
+      headers: {'Authorization' => "bearer #{token}"})
   end
 
   def get_json(path)

--- a/app/views/invitation_mailer/invite.html.erb
+++ b/app/views/invitation_mailer/invite.html.erb
@@ -1,0 +1,8 @@
+<% uri = "/register" %>
+<% production =  "http://brownfielddreams.herokuapp.com" + uri %>
+<% dev_test =  "http://localhost:3000" + uri %>
+<% url = Rails.env == 'production' ? production : dev_test %>
+
+Hello <%= @real_name %>,
+
+<%= @inviter %> has invited you to join Turing Tutorials. You can <%= link_to "create an account here", url %>.

--- a/app/views/invitation_mailer/invite.txt.erb
+++ b/app/views/invitation_mailer/invite.txt.erb
@@ -1,0 +1,8 @@
+<% uri = "/register" %>
+<% production =  "http://brownfielddreams.herokuapp.com" + uri %>
+<% dev_test =  "http://localhost:3000" + uri %>
+<% url = Rails.env == 'production' ? production : dev_test %>
+
+Hello <%= @real_name %>,
+
+<%= @inviter %> has invited you to join Turing Tutorials. You can <%= link_to "create an account here", url %>.

--- a/app/views/invite/new.html.erb
+++ b/app/views/invite/new.html.erb
@@ -1,5 +1,5 @@
+<h3>Enter a friend's GitHub handle</h3>
 <%= form_tag('/invite/create') do %>
-  <%= label_tag "GitHub Handle" %>
-  <%= text_field_tag "GitHub Handle" %>
-  <%= submit_tag "Send Invite" %>
+  <p><%= text_field_tag "GitHub Handle" %></p>
+  <%= submit_tag "Send Invite", class: "btn btn-primary mb1 bg-teal" %>
 <% end %>

--- a/app/views/invite/new.html.erb
+++ b/app/views/invite/new.html.erb
@@ -1,0 +1,5 @@
+<%= form_tag('/invite/create') do %>
+  <%= label_tag "GitHub Handle" %>
+  <%= text_field_tag "GitHub Handle" %>
+  <%= submit_tag "Send Invite" %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
   </ul>
 
   <% if active_user? %>
-    <%= link_to "Send an Invite", '/invite' %>
+    <%= link_to "Send an Invite", '/invite', class: "btn btn-primary mb1 bg-teal" %>
 
     <%= render partial: 'partials/dashboard/bookmarks', locals: {user: @user, has_bookmarks: @user.has_bookmarks?} %>
     <%= render partial: 'partials/dashboard/friends', locals: {user: @user, has_friends: @user.has_friends?} %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,6 +11,8 @@
   </ul>
 
   <% if active_user? %>
+    <%= link_to "Send an Invite", '/invite' %>
+
     <%= render partial: 'partials/dashboard/bookmarks', locals: {user: @user, has_bookmarks: @user.has_bookmarks?} %>
     <%= render partial: 'partials/dashboard/friends', locals: {user: @user, has_friends: @user.has_friends?} %>
     <hr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
   get '/auth/github', as: :github_auth
   get '/auth/github/callback', to: 'users#update'
 
+  get "/invite", to: 'invite#new'
+  post "/invite/create", to: 'invite#create'
+
   resources :friendships, only: [:create]
   delete '/friendship', to: 'friendships#destroy'
 

--- a/spec/features/user/user_can_send_an_email_invite_spec.rb
+++ b/spec/features/user/user_can_send_an_email_invite_spec.rb
@@ -4,25 +4,24 @@ describe 'As a registered user' do
   scenario "I can send an email invite to a github user with the public email" do
     VCR.turn_off!
     WebMock.allow_net_connect!
-    # When I visit /dashboard
+
     user = create(:user)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     visit dashboard_path
-    # And I click "Send an Invite"
+
     click_link "Send an Invite"
-    # Then I should be on /invite
+
     expect(current_path).to eq('/invite')
-    # And when I fill in "Github Handle" with <A VALID GITHUB HANDLE>
+
     valid_github_handle = 'fentontaylor'
+    
     fill_in "GitHub Handle", with: valid_github_handle
 
-    # And I click on "Send Invite"
     click_button "Send Invite"
-    # Then I should be on /dashboard
+
     expect(current_path).to eq(dashboard_path)
-    # And I should see a message that says "Successfully sent invite!" (if the user has an email address associated with their github account)
+
     expect(page).to have_content("Successfully sent invite!")
-    # Or I should see a message that says "The Github user you selected doesn't have an email address associated with their account."
   end
 end

--- a/spec/features/user/user_can_send_an_email_invite_spec.rb
+++ b/spec/features/user/user_can_send_an_email_invite_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe 'As a registered user' do
+  scenario "I can send an email invite to a github user with the public email" do
+    VCR.turn_off!
+    WebMock.allow_net_connect!
+    # When I visit /dashboard
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit dashboard_path
+    # And I click "Send an Invite"
+    click_link "Send an Invite"
+    # Then I should be on /invite
+    expect(current_path).to eq('/invite')
+    # And when I fill in "Github Handle" with <A VALID GITHUB HANDLE>
+    valid_github_handle = 'fentontaylor'
+    fill_in "GitHub Handle", with: valid_github_handle
+
+    # And I click on "Send Invite"
+    click_button "Send Invite"
+    # Then I should be on /dashboard
+    expect(current_path).to eq(dashboard_path)
+    # And I should see a message that says "Successfully sent invite!" (if the user has an email address associated with their github account)
+    expect(page).to have_content("Successfully sent invite!")
+    # Or I should see a message that says "The Github user you selected doesn't have an email address associated with their account."
+  end
+end

--- a/spec/mailers/invitation_spec.rb
+++ b/spec/mailers/invitation_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe InvitationMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/invitation_preview.rb
+++ b/spec/mailers/previews/invitation_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/invitation
+class InvitationPreview < ActionMailer::Preview
+
+end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,21 +1,69 @@
 require 'rails_helper'
 
 describe "GithubService" do
-  it "returns parsed repo data" do
+  before :each do
     VCR.turn_off!
     nancy = User.create!(email: 'nancy@example.com', first_name: 'Nancy', last_name: 'Lee', password:  "password", role: :default, token: ENV['GITHUB_API_KEY_NL'])
-    
-    nancys_repos = File.open('./fixtures/nancys_repos.json')
-    stub_request(:get, 'https://api.github.com/user/repos?affiliation=owner')
-      .to_return(status: 200, body: nancys_repos)
 
-    service = GithubService.new(nancy)
+    stub_github_info("nancys")
 
-    github_repos = service.get_repos
+    @service = GithubService.new(nancy)
+  end
+
+  it "returns parsed repo data" do
+    github_repos = @service.get_repos
 
     expect(github_repos).to be_an Array
 
     expect(github_repos.first).to have_key(:name)
     expect(github_repos.first).to have_key(:html_url)
+  end
+
+  it "returns parsed follower data" do
+    github_followers = @service.get_followers
+
+    expect(github_followers).to be_an Array
+
+    expect(github_followers.first).to have_key(:login)
+    expect(github_followers.first).to have_key(:html_url)
+  end
+
+  it "returns parsed following data" do
+    github_following = @service.get_following
+
+    expect(github_following).to be_an Array
+
+    expect(github_following.first).to have_key(:login)
+    expect(github_following.first).to have_key(:html_url)
+  end
+end
+
+describe 'Email invite' do
+  it "returns public email" do
+    VCR.turn_off!
+    WebMock.allow_net_connect!
+
+    user = create(:user)
+    service = GithubService.new(user)
+
+    valid_handle = 'fentontaylor'
+    data_1 = service.get_email(valid_handle)
+
+    expect(data_1[:email]).to eq('fentontaylor@gmail.com')
+
+    valid_handle_no_email = 'nancylee713'
+    data_2 = service.get_email(valid_handle_no_email)
+
+    expect(data_2[:email]).to eq(nil)
+
+    invalid_handle = 'asdfkljd;'
+    no_data =  service.get_email(invalid_handle)
+
+    result = {
+      message: "Not Found",
+      documentation_url: "https://developer.github.com/v3/users/#get-a-single-user"
+    }
+
+    expect(no_data).to eq(result)
   end
 end


### PR DESCRIPTION
This PR (user story: #6 ) adds the following:
- An active user (email verified) can send an invite to a github user
- Add `#get_email(handle)` method to `GithubService`  poro
- Add InvitationMailer, InviteController, and relevant view pages
- Add InviteFacade to refactor `#create` action within InviteController
