### PR TITLE
Videos do not reload 

### DIFF
--- a/app/controllers/api/v1/bookmarks_controller.rb
+++ b/app/controllers/api/v1/bookmarks_controller.rb
@@ -1,0 +1,20 @@
+class Api::V1::BookmarksController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    user_video = UserVideo.new(user_video_params)
+    if current_user.user_videos.find_by(video_id: user_video.video_id)
+#flash messages will no longer work due to fetch call. Need a solution to this.
+      flash[:error] = "Already in your bookmarks"
+    elsif user_video.save
+      flash[:success] = "Bookmark added to your dashboard!"
+    end
+    redirect_back(fallback_location: root_path)
+  end
+
+  private
+
+  def user_video_params
+    params.permit(:user_id, :video_id)
+  end
+end

--- a/app/javascript/packs/controllers/tutorials_controller.js
+++ b/app/javascript/packs/controllers/tutorials_controller.js
@@ -12,6 +12,23 @@ export default class extends Controller {
       });
   }
 
+bookmarkVideo(event) {
+  event.preventDefault();
+   fetch(`/api/v1/bookmarks`, {
+     method: 'POST',
+     body: JSON.stringify({"user_id": event.target.getAttribute("user_id"), "video_id": event.target.getAttribute("video_id")}),
+     headers: {
+       'Content-Type': 'application/json',
+       'X-CSRF-Token': Rails.csrfToken ()
+     },
+     credentials: 'same-origin'
+   }).then(function(response) {
+     return response.json();
+   }).then(function(data) {
+     console.log(data);
+   });
+}
+
   showVideoForm(event) {
     event.preventDefault();
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,11 +4,11 @@
     <title>TuringTutorials</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= javascript_include_tag "application" %>
+    <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
 
     <link href="https://unpkg.com/basscss@7.1.1/css/basscss.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700,800" rel="stylesheet">
-    <%= javascript_pack_tag 'application' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', async: true %>
     <%= stylesheet_link_tag 'application' %>
   </head>
   <body>

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -18,7 +18,13 @@
         <h3><%= @facade.current_video.title %></h3>
           <div class="bookmarks-btn">
             <% if current_user %>
-              <%= button_to "Bookmark", user_videos_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
+
+            <div data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
+              <%= button_to "Bookmark", "#", "data-action" => "click->tutorials#bookmarkVideo", video_id: @facade.current_video.id, user_id: current_user.id, class: "btn btn-outline mb1 teal"%>
+            </div>
+
+
+              <%# <%= button_to "Bookmark", api_v1_bookmarks_path(video_id: @facade.current_video.id, user_id: current_user.id), method: :post, class: "btn btn-outline mb1 teal" %>
             <% else %>
             <div class="bookmark">
               <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-html="true" data-placement="top" title="You must be a registered user to bookmark this tutorial.">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :tutorials, only:[:show, :index]
-      resources :videos, only:[:show]
+      resources :tutorials, only: [:show, :index]
+      resources :videos, only: [:show]
+      resources :bookmarks, only: [:create]
     end
   end
 

--- a/public/packs-test/manifest.json
+++ b/public/packs-test/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs-test/application-880e3a31c9d4c55bac14.js",
-  "application.js.map": "/packs-test/application-880e3a31c9d4c55bac14.js.map",
-  "controllers/tutorials_controller.js": "/packs-test/controllers/tutorials_controller-6342109e8d1e47aeac00.js",
-  "controllers/tutorials_controller.js.map": "/packs-test/controllers/tutorials_controller-6342109e8d1e47aeac00.js.map"
+  "application.js": "/packs-test/application-1c5c5a2504ce7268e6f9.js",
+  "application.js.map": "/packs-test/application-1c5c5a2504ce7268e6f9.js.map",
+  "controllers/tutorials_controller.js": "/packs-test/controllers/tutorials_controller-fae989f3cc0b6dea0fd8.js",
+  "controllers/tutorials_controller.js.map": "/packs-test/controllers/tutorials_controller-fae989f3cc0b6dea0fd8.js.map"
 }

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-2478f464d61db1eeaeab.js",
-  "application.js.map": "/packs/application-2478f464d61db1eeaeab.js.map",
-  "controllers/tutorials_controller.js": "/packs/controllers/tutorials_controller-c137c438bffe4c0e9d9e.js",
-  "controllers/tutorials_controller.js.map": "/packs/controllers/tutorials_controller-c137c438bffe4c0e9d9e.js.map"
+  "application.js": "/packs/application-b123da3030c4dc1b9564.js",
+  "application.js.map": "/packs/application-b123da3030c4dc1b9564.js.map",
+  "controllers/tutorials_controller.js": "/packs/controllers/tutorials_controller-9dfbb98523433e775b8a.js",
+  "controllers/tutorials_controller.js.map": "/packs/controllers/tutorials_controller-9dfbb98523433e775b8a.js.map"
 }

--- a/spec/features/user/bookmarking_a_video_does_not_reload_video_playing_spec.rb
+++ b/spec/features/user/bookmarking_a_video_does_not_reload_video_playing_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe 'As a registered user' do
+  before :each do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    @tutorial = create(:tutorial)
+    create(:video, tutorial: @tutorial)
+
+  end
+
+  it 'when i visit a tutorial and click_on the bookmark button the page does not reload and the video is added to my bookmarks' do
+    visit(tutorial_path(@tutorial.id))
+    click_button("Bookmark")
+#when capybara clicks button it errors out with 'No route matches [POST] "/"', however the function works on localhost.
+    expect(current_path).to eq(tutorial_path(@tutorial.id))
+#need to figure out how to test for page not reloading.
+    visit dashboard_path
+    within :bookmarked do
+        expect(page).to have_content(@tutorial.title)
+    end 
+  end
+end


### PR DESCRIPTION
This PR does the following: 
- Adds a namespaced route for new bookmarks controller
- Adds namespaced bookmark controller 
- Moves previous bookmark controller functionality to new controller
- Improves user experience by adding bookmarkVideo function that incorporates fetch to enable a user to bookmark a video without reloading the page and starting the video over
- Refactors bookmark video button to route to new action

**Functionality works on localhost however testing in this PR needs work. I need to do further research into the problems I am having. There are notes in the test file if you would like to take a look.**
