### PR TITLE
Import youtube playlist

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -6,6 +6,7 @@ class Admin::TutorialsController < Admin::BaseController
   def create
     @tutorial = Tutorial.new(tutorial_params)
     if @tutorial.save
+      add_videos(@tutorial) if tutorial_params[:playlist_id]
       flash[:success] = 'Successfully created tutorial.'
       redirect_to tutorial_path(@tutorial)
     else
@@ -36,6 +37,6 @@ class Admin::TutorialsController < Admin::BaseController
 
   private
   def tutorial_params
-    params.require(:tutorial).permit(:title, :description, :thumbnail, :classroom, :tag_list)
+    params.require(:tutorial).permit(:title, :description, :thumbnail, :classroom, :tag_list, :playlist_id)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,4 +36,18 @@ class ApplicationController < ActionController::Base
   def four_oh_four
     render file: 'public/404', status: 404
   end
+
+  def add_videos(tutorial)
+    response = Faraday.get("https://www.googleapis.com/youtube/v3/playlistItems?key=#{ENV['YOUTUBE_API_KEY']}&playlistId=#{tutorial.playlist_id}&part=snippet&maxResults=50&order=date")
+    data = JSON.parse(response.body, symbolize_names: true)
+    data[:items].each.with_index(1) do |vid, index|
+      tutorial.videos.create!(
+        title:       vid[:snippet][:title],
+        description: vid[:snippet][:description],
+        thumbnail:   vid[:snippet][:thumbnails][:high][:url],
+        video_id:    vid[:snippet][:resourceId][:videoId],
+        position:    index
+      )
+    end
+  end
 end

--- a/app/views/admin/tutorials/_playlist_form.html.erb
+++ b/app/views/admin/tutorials/_playlist_form.html.erb
@@ -1,4 +1,4 @@
-  <%= form_for @tutorial, remote: true do |f| %>
+<%= form_for @tutorial, remote: true do |f| %>
   <%= f.label :playlist_id %>
   <%= f.text_field :playlist_id %>
 <% end %>

--- a/app/views/admin/tutorials/_playlist_form.html.erb
+++ b/app/views/admin/tutorials/_playlist_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: tutorial) do |f| %>
+  <%= form_for @tutorial, remote: true do |f| %>
   <%= f.label :playlist_id %>
   <%= f.text_field :playlist_id %>
 <% end %>

--- a/app/views/admin/tutorials/_playlist_form.html.erb
+++ b/app/views/admin/tutorials/_playlist_form.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: tutorial) do |f| %>
+  <%= f.label :playlist_id %>
+  <%= f.text_field :playlist_id %>
+<% end %>

--- a/app/views/admin/tutorials/new.html.erb
+++ b/app/views/admin/tutorials/new.html.erb
@@ -13,6 +13,11 @@
 
   <h3>Videos</h3>
 
+<div id="import-youtube-playlist-link">
+  <%= link_to 'Import YouTube Playlist', new_admin_tutorial_path, remote: true %>
+</div>
+
+
   <%= f.fields_for :videos do |builder| %>
     <%= f.label :youtube_url %>
     <%= f.text_field :video_id, class: "block col-4 field" %>

--- a/app/views/admin/tutorials/new.html.erb
+++ b/app/views/admin/tutorials/new.html.erb
@@ -17,7 +17,6 @@
   <%= link_to 'Import YouTube Playlist', new_admin_tutorial_path, remote: true %>
 </div>
 
-
   <%= f.fields_for :videos do |builder| %>
     <%= f.label :youtube_url %>
     <%= f.text_field :video_id, class: "block col-4 field" %>

--- a/app/views/admin/tutorials/new.js.erb
+++ b/app/views/admin/tutorials/new.js.erb
@@ -1,0 +1,1 @@
+$('#import-youtube-playlist-link a').parent().html("<%= j render 'playlist_form', tutorial: @tutorial %>")

--- a/public/packs-test/manifest.json
+++ b/public/packs-test/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs-test/application-1c5c5a2504ce7268e6f9.js",
-  "application.js.map": "/packs-test/application-1c5c5a2504ce7268e6f9.js.map",
-  "controllers/tutorials_controller.js": "/packs-test/controllers/tutorials_controller-fae989f3cc0b6dea0fd8.js",
-  "controllers/tutorials_controller.js.map": "/packs-test/controllers/tutorials_controller-fae989f3cc0b6dea0fd8.js.map"
+  "application.js": "/packs-test/application-b2efce7ff800a6ad38d7.js",
+  "application.js.map": "/packs-test/application-b2efce7ff800a6ad38d7.js.map",
+  "controllers/tutorials_controller.js": "/packs-test/controllers/tutorials_controller-98bf2c221bf8df87cc8d.js",
+  "controllers/tutorials_controller.js.map": "/packs-test/controllers/tutorials_controller-98bf2c221bf8df87cc8d.js.map"
 }

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-b123da3030c4dc1b9564.js",
-  "application.js.map": "/packs/application-b123da3030c4dc1b9564.js.map",
-  "controllers/tutorials_controller.js": "/packs/controllers/tutorials_controller-9dfbb98523433e775b8a.js",
-  "controllers/tutorials_controller.js.map": "/packs/controllers/tutorials_controller-9dfbb98523433e775b8a.js.map"
+  "application.js": "/packs/application-d35c83613c6e27789cda.js",
+  "application.js.map": "/packs/application-d35c83613c6e27789cda.js.map",
+  "controllers/tutorials_controller.js": "/packs/controllers/tutorials_controller-349aa2fc985e2bb12fac.js",
+  "controllers/tutorials_controller.js.map": "/packs/controllers/tutorials_controller-349aa2fc985e2bb12fac.js.map"
 }

--- a/spec/features/admin/admin_can_import_youtube_playlist_spec.rb
+++ b/spec/features/admin/admin_can_import_youtube_playlist_spec.rb
@@ -8,7 +8,7 @@ describe "An Admin can import youtube playlist" do
       .and_return(admin)
   end
 
-  it "When I visit new tutorial creation page" do
+  it "When I visit new tutorial creation page", :js do
     visit new_admin_tutorial_path
 
     title = 'New Tutorial Title'
@@ -21,6 +21,7 @@ describe "An Admin can import youtube playlist" do
 
     click_on 'Import YouTube Playlist'
 
+    # capybara cannot find remote form params, but functionality works in development
     fill_in "tutorial[playlist_id]", with: "PL1Y67f0xPzdOq2FcpWnawJeyJ3ELUdBkJ"
 
     click_on "Save"

--- a/spec/features/admin/admin_can_import_youtube_playlist_spec.rb
+++ b/spec/features/admin/admin_can_import_youtube_playlist_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe "An Admin can import youtube playlist" do
+  before :each do
+    admin = create(:user, role: 1)
+    allow_any_instance_of(ApplicationController)
+      .to receive(:current_user)
+      .and_return(admin)
+  end
+
+  it "When I visit new tutorial creation page" do
+    visit new_admin_tutorial_path
+
+    title = 'New Tutorial Title'
+    description = 'This is a description'
+    thumbnail = 'thumbnail.jpg'
+
+    fill_in 'Title', with: title
+    fill_in 'Description', with: description
+    fill_in 'Thumbnail', with: thumbnail
+
+    click_on 'Import YouTube Playlist'
+
+    fill_in "tutorial[playlist_id]", with: "PL1Y67f0xPzdOq2FcpWnawJeyJ3ELUdBkJ"
+
+    click_on "Save"
+
+    tutorial = Tutorial.last
+
+    expect(current_path).to eq admin_dashboard_path
+
+    expect(page).to have_content('Successfully created tutorial. View it here.')
+
+    expect(page).to have_link('View it here')
+
+    click_on 'View it here'
+
+    expect(current_path).to eq tutorial_path(tutorial)
+
+    expect(page).to have_content(tutorial.videos.first.title)
+    expect(page).to have_content(tutorial.videos.second.title)
+  end
+end

--- a/spec/features/admin/edit_tutorial_spec.rb
+++ b/spec/features/admin/edit_tutorial_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 describe "An Admin can edit a tutorial" do
+
+  VCR.turn_off!(:ignore_cassettes => true)
+  WebMock.allow_net_connect!
+
   let(:tutorial) { create(:tutorial) }
   let(:admin)    { create(:admin) }
 

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,0 +1,15 @@
+module WaitForAjax
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end
+
+RSpec.configure do |config|
+  config.include WaitForAjax, type: :feature
+end


### PR DESCRIPTION
This PR adds the following:
- On a new tutorial form, the admin can click a button (i.e, `Import Youtube Playlist`). A button click renders a remote form on the same page for the admin, to fill in the form with a youtube playlist id.
- The functionality seems to be working in development; but I have no clue how this can be tested on rspec/capybara.