### PR TITLE
Change video description id

### DIFF
--- a/app/javascript/packs/controllers/tutorials_controller.js
+++ b/app/javascript/packs/controllers/tutorials_controller.js
@@ -7,7 +7,7 @@ export default class extends Controller {
     fetch(`/api/v1/videos/${event.target.id}`)
       .then((response) => response.json())
       .then(function(response){
-        const desc = document.querySelector(`#description-${event.target.id}`);
+        const desc = document.querySelector(`#longer-description-${event.target.id}`);
         desc.innerHTML = response.description
       });
   }

--- a/app/views/tutorials/show.html.erb
+++ b/app/views/tutorials/show.html.erb
@@ -72,7 +72,7 @@
       </div>
       <div>
         <h4>Description</h4>
-        <p data-controller="tutorials" id="description-<%= @facade.current_video.id %>">
+        <p data-controller="tutorials" id="longer-description-<%= @facade.current_video.id %>">
           <%= @facade.current_video.description.truncate(50) %>...
           <%= link_to "More", "#", "data-action" => "click->tutorials#showDescription", id: @facade.current_video.id, class: "show-link"%>
         </p>

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "application.js": "/packs/application-fbec1ccb54d8a92d946d.js",
-  "application.js.map": "/packs/application-fbec1ccb54d8a92d946d.js.map",
-  "controllers/tutorials_controller.js": "/packs/controllers/tutorials_controller-34247b7bdf82267acd8b.js",
-  "controllers/tutorials_controller.js.map": "/packs/controllers/tutorials_controller-34247b7bdf82267acd8b.js.map"
+  "application.js": "/packs/application-25fe1c45f4ac5638f277.js",
+  "application.js.map": "/packs/application-25fe1c45f4ac5638f277.js.map",
+  "controllers/tutorials_controller.js": "/packs/controllers/tutorials_controller-d10346d0275e9ce40bff.js",
+  "controllers/tutorials_controller.js.map": "/packs/controllers/tutorials_controller-d10346d0275e9ce40bff.js.map"
 }


### PR DESCRIPTION
This PR changes the video description id to fix the bug we had where the description was jumping to the top of the page when you clicked "more".